### PR TITLE
feat: add base time entity to user

### DIFF
--- a/src/main/java/kr/or/cola/backend/BackendApplication.java
+++ b/src/main/java/kr/or/cola/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package kr.or.cola.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/kr/or/cola/backend/common/BaseTimeEntity.java
+++ b/src/main/java/kr/or/cola/backend/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package kr.or.cola.backend.common;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @Column(name = "created_at")
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @Column(name = "updated_at")
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+}

--- a/src/main/java/kr/or/cola/backend/user/domain/User.java
+++ b/src/main/java/kr/or/cola/backend/user/domain/User.java
@@ -1,5 +1,6 @@
 package kr.or.cola.backend.user.domain;
 
+import kr.or.cola.backend.common.BaseTimeEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +16,7 @@ import javax.persistence.*;
         initialValue = 1,
         allocationSize=1
 )
-public class User{
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name= "id")


### PR DESCRIPTION
### 🔨 작업 내용
- Base time entity 생성 및 적용
### 📐 구현한 내용
- User entity에 created_at, updated_at 칼럼 자동 생성되도록 abstract class 생성
- main 실행파일에 JPA Auditing annotation 추가
### 🚧 논의 사항
- 
