### PR TITLE
Fix/hiding redirect uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-/src/main/resources/application-oauth.properties
-/src/main/resources/application-database.properties
-/src/main/resources/application-mail.properties
+!**/application-test.properties
+**/application-**.properties

--- a/src/main/java/kr/or/cola/backend/config/SecurityConfig.java
+++ b/src/main/java/kr/or/cola/backend/config/SecurityConfig.java
@@ -4,15 +4,21 @@ import kr.or.cola.backend.oauth.OAuth2AuthenticationSuccessHandler;
 import kr.or.cola.backend.user.UserService;
 import kr.or.cola.backend.user.domain.Role;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final UserService userService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @Value("${cola.redirect-uri.sign-in}")
+    private String signInUrl;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -35,5 +41,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .userInfoEndpoint()
                     .userService(userService);
 
+    }
+
+    @Bean
+    SimpleUrlAuthenticationFailureHandler failureHandler() {
+        return new SimpleUrlAuthenticationFailureHandler(signInUrl);
     }
 }

--- a/src/main/java/kr/or/cola/backend/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/kr/or/cola/backend/oauth/dto/OAuthAttributes.java
@@ -27,7 +27,6 @@ public class OAuthAttributes {
         return OAuthAttributes.builder()
                 .email((String) attributes.get("email"))
                 .attributes(attributes)
-                .attributes(attributes)
                 .nameAttributeKey(userNameAttributeName)
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.profiles.include=oauth,database,mail
+spring.profiles.include=auth,database,mail
 
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 


### PR DESCRIPTION
### 🔨 작업 내용
- redirect uri 은닉화 및 login handler 수정
### 📐 구현한 내용
- 기존 하드코딩 되어있던 uri를 properties 파일로 이동 후 은닉화
- login success handler 수정
- login failure handler 생성 (security config에서 bean 생성)
### 🚧 논의 사항
- 
