### PR TITLE
Feature/s3 controller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,6 @@ dependencies {
 	implementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
 	// oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
@@ -40,6 +37,9 @@ dependencies {
 	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'javax.validation:validation-api'
+
+	// aws setting
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	// test
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/kr/or/cola/backend/aws/presentation/AwsS3Controller.java
+++ b/src/main/java/kr/or/cola/backend/aws/presentation/AwsS3Controller.java
@@ -23,7 +23,7 @@ public class AwsS3Controller {
 
     /**
      * Amazon S3에 파일 업로드
-     * @return 성공 시 200 Success와 함께 업로드 된 파일의 파일명 리스트 반환
+     * @return 성공 시 200 Success와 함께 업로드 된 파일의 url 리스트 반환
      */
     @ApiOperation(value = "Amazon S3에 파일 업로드", notes = "Amazon S3에 파일 업로드 ")
     @PostMapping("/file")

--- a/src/main/java/kr/or/cola/backend/aws/presentation/AwsS3Controller.java
+++ b/src/main/java/kr/or/cola/backend/aws/presentation/AwsS3Controller.java
@@ -1,0 +1,44 @@
+package kr.or.cola.backend.aws.presentation;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import java.util.List;
+import kr.or.cola.backend.aws.service.AwsS3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/s3")
+public class AwsS3Controller {
+
+    private final AwsS3Service awsS3Service;
+
+    /**
+     * Amazon S3에 파일 업로드
+     * @return 성공 시 200 Success와 함께 업로드 된 파일의 파일명 리스트 반환
+     */
+    @ApiOperation(value = "Amazon S3에 파일 업로드", notes = "Amazon S3에 파일 업로드 ")
+    @PostMapping("/file")
+    public ResponseEntity<List<String>> uploadFile(@ApiParam(value="파일들(여러 파일 업로드 가능)", required = true) @RequestPart List<MultipartFile> multipartFile) {
+        return ResponseEntity.ok(awsS3Service.uploadFile(multipartFile));
+    }
+
+    /**
+     * Amazon S3에 업로드 된 파일을 삭제
+     * @return 성공 시 200 Success
+     */
+    @ApiOperation(value = "Amazon S3에 업로드 된 파일을 삭제", notes = "Amazon S3에 업로드된 파일 삭제")
+    @DeleteMapping("/file")
+    public ResponseEntity<Void> deleteFile(@ApiParam(value="파일 하나 삭제", required = true) @RequestParam String fileName) {
+        awsS3Service.deleteFile(fileName);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/kr/or/cola/backend/aws/service/AwsS3Service.java
+++ b/src/main/java/kr/or/cola/backend/aws/service/AwsS3Service.java
@@ -32,7 +32,6 @@ public class AwsS3Service {
     public List<String> uploadFile(List<MultipartFile> files) {
         List<String> fileUrlList = new ArrayList<>();
 
-        // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileNameList에 추가
         files.forEach(file -> {
             if(!Objects.requireNonNull(file.getContentType()).startsWith("image")){
                 throw new IllegalArgumentException("이미지 파일이 아닙니다.");

--- a/src/main/java/kr/or/cola/backend/aws/service/AwsS3Service.java
+++ b/src/main/java/kr/or/cola/backend/aws/service/AwsS3Service.java
@@ -1,0 +1,76 @@
+package kr.or.cola.backend.common.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+@Service
+public class AwsS3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 amazonS3;
+
+    public List<String> uploadFile(List<MultipartFile> files) {
+        List<String> fileNameList = new ArrayList<>();
+
+        // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileNameList에 추가
+        files.forEach(file -> {
+            if(!Objects.requireNonNull(file.getContentType()).startsWith("image")){
+                return;
+            }
+            String fileName = createFileName(file.getOriginalFilename());
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            try(InputStream inputStream = file.getInputStream()) {
+                amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+            } catch(IOException e) {
+                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패했습니다.");
+            }
+
+            fileNameList.add(fileName);
+        });
+
+        return fileNameList;
+    }
+
+    public void deleteFile(String fileName) {
+        if (!amazonS3.doesObjectExist(bucket, fileName)) {
+            throw new AmazonS3Exception("Object " + fileName + " does not exist!");
+        }
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
+    }
+
+    private String createFileName(String fileName) { // 파일 업로드 시, 파일명을 난수화하기 위해 random 사용
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName) { // file 형식이 잘못된 경우를 확인하기 위해 만들어진 로직이며, 파일 타입과 상관없이 업로드할 수 있게 하기 위해 .의 존재 유무만 판단하였습니다.
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
+        }
+    }
+
+}

--- a/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
+++ b/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/api/v1")
+@RequestMapping("/v1")
 @RequiredArgsConstructor
 @RestController
 public class CommentController {

--- a/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
+++ b/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/v1")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class CommentController {

--- a/src/main/java/kr/or/cola/backend/common/presentation/RootController.java
+++ b/src/main/java/kr/or/cola/backend/common/presentation/RootController.java
@@ -1,2 +1,13 @@
-package kr.or.cola.backend.common.presentation;public class RootController {
+package kr.or.cola.backend.common.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RootController {
+    @GetMapping("/")
+    public ResponseEntity<String> home() {
+        return ResponseEntity.ok("COLA server is running");
+    }
 }

--- a/src/main/java/kr/or/cola/backend/common/presentation/RootController.java
+++ b/src/main/java/kr/or/cola/backend/common/presentation/RootController.java
@@ -1,0 +1,2 @@
+package kr.or.cola.backend.common.presentation;public class RootController {
+}

--- a/src/main/java/kr/or/cola/backend/config/AwsS3Config.java
+++ b/src/main/java/kr/or/cola/backend/config/AwsS3Config.java
@@ -1,0 +1,2 @@
+package kr.or.cola.backend.config;public class AwsS3Config {
+}

--- a/src/main/java/kr/or/cola/backend/config/AwsS3Config.java
+++ b/src/main/java/kr/or/cola/backend/config/AwsS3Config.java
@@ -1,2 +1,30 @@
-package kr.or.cola.backend.config;public class AwsS3Config {
+package kr.or.cola.backend.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+            .withRegion(region)
+            .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+            .build();
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=80
+
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 
 # session
@@ -34,12 +36,11 @@ spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
 # aws s3
-spring.profiles.include=aws
-#cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
-#cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
-#cloud.aws.s3.bucket=${S3_BUCKET}
-#cloud.aws.region.static=ap-northeast-2
-#cloud.aws.stack.auto=false
+cloud.aws.credentials.accessKey=${S3_ACCESS_KEY:test}
+cloud.aws.credentials.secretKey=${S3_SECRET_KEY:test}
+cloud.aws.s3.bucket=${S3_BUCKET:test}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.stack.auto=false
 
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,17 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
+# aws s3
+spring.profiles.include=aws
+#cloud.aws.credentials.accessKey=${S3_ACCESS_KEY}
+#cloud.aws.credentials.secretKey=${S3_SECRET_KEY}
+#cloud.aws.s3.bucket=${S3_BUCKET}
+#cloud.aws.region.static=ap-northeast-2
+#cloud.aws.stack.auto=false
+
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB
+
 # redirect uri
 cola.redirect-uri.main=${COLA_BASE_URL}
 cola.redirect-uri.sign-up=${COLA_BASE_URL}${COLA_SIGN_UP_PATH}


### PR DESCRIPTION
### 🔨 작업 내용
- AWS S3 파일 업로드 service, controller 구현
### 📐 구현한 내용
- S3 config 설정
- S3 service, controller 구현
  - `uploadFile()` - **_multipart/form-data 방식으로 전송_**
    - 다수의 파일 업로드 가능
    - 이미지 형식의 파일만 업로드 가능 (파일 형식이 맞지 않으면 exception 발생)
    - 업로드 된 파일의 url list 반환
  - `deleteFile()`
    - 파일 이름 입력 시, 해당 파일 s3에서 삭제 (추후 보완 필요)
### 🚧 논의 사항
- S3 bean을 생성하기 위해 사용하는 환경변수 추가 필요
  - 현재는 `application-aws.properties`를 include해서 사용 중
  - 환경변수 이름은 `application.properties`에 주석처리하여 생성한 상태
- post에서 image file name을 따로 관리할 필요성에 대해 논의 필요
  - 이미지 url의 경우 어차피 마크다운 형식으로 작성하기에 string으로 입력
  - 하지만 **_썸네일 이미지_** 를 고르기 위해 post에 업로드 한 이미지를 리스트로 따로 제공해 줄 필요가 있을 것으로 예상
