### PR TITLE
fix: change createComment controller response

### DIFF
--- a/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
+++ b/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
@@ -1,6 +1,7 @@
 package kr.or.cola.backend.comment.presentation;
 
 import kr.or.cola.backend.comment.presentation.dto.CommentCreateOrUpdateRequestDto;
+import kr.or.cola.backend.comment.presentation.dto.CommentResponseDto;
 import kr.or.cola.backend.comment.service.CommentService;
 import kr.or.cola.backend.oauth.LoginUser;
 import kr.or.cola.backend.oauth.dto.SessionUser;
@@ -22,11 +23,11 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity<Long> createComment(@LoginUser SessionUser user,
+    public ResponseEntity<CommentResponseDto> createComment(@LoginUser SessionUser user,
         @PathVariable Long postId, @RequestBody CommentCreateOrUpdateRequestDto requestDto) {
-        Long commentId = commentService.createComment(user.getUserId(),
-            postId, requestDto);
-        return ResponseEntity.ok(commentId);
+        CommentResponseDto responseDto = new CommentResponseDto(
+            commentService.createComment(user.getUserId(), postId, requestDto));
+        return ResponseEntity.ok(responseDto);
     }
 
     @PatchMapping("/comments/{commentId}")

--- a/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
+++ b/src/main/java/kr/or/cola/backend/comment/presentation/CommentController.java
@@ -8,6 +8,7 @@ import kr.or.cola.backend.oauth.dto.SessionUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentService commentService;
+
+    @GetMapping("/comments/{commentId}")
+    public ResponseEntity<CommentResponseDto> getComment(@PathVariable Long commentId) {
+        return ResponseEntity.ok(commentService.getComment(commentId));
+    }
 
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<CommentResponseDto> createComment(@LoginUser SessionUser user,

--- a/src/main/java/kr/or/cola/backend/comment/service/CommentService.java
+++ b/src/main/java/kr/or/cola/backend/comment/service/CommentService.java
@@ -28,7 +28,7 @@ public class CommentService {
         return new CommentResponseDto(initializeCommentInfo(commentId));
     }
 
-    public Long createComment(Long userId, Long postId, CommentCreateOrUpdateRequestDto requestDto) {
+    public Comment createComment(Long userId, Long postId, CommentCreateOrUpdateRequestDto requestDto) {
         User user = findUserById(userId);
         Post post = findPostById(postId);
         Comment comment = Comment.builder()
@@ -36,7 +36,7 @@ public class CommentService {
             .post(post)
             .content(requestDto.getContent())
             .build();
-        return commentRepository.save(comment).getId();
+        return commentRepository.save(comment);
     }
 
     public void updateComment(Long userId, Long commentId, CommentCreateOrUpdateRequestDto requestDto) {


### PR DESCRIPTION
### 🔨 작업 내용
- create controller 응답 형식 변경
### 📐 구현한 내용
- 기존 Long type의 comment ID 반환에서 comment response dto 형태로 변경
### 🚧 논의 사항
- 
