### PR TITLE
Feat/add get post list controller

### DIFF
--- a/src/main/java/kr/or/cola/backend/auth/AuthTokenController.java
+++ b/src/main/java/kr/or/cola/backend/auth/AuthTokenController.java
@@ -5,6 +5,7 @@ import kr.or.cola.backend.auth.dto.AuthMailRequestDto;
 import kr.or.cola.backend.oauth.LoginUser;
 import kr.or.cola.backend.oauth.dto.SessionUser;
 import kr.or.cola.backend.user.UserService;
+import kr.or.cola.backend.user.domain.Role;
 import kr.or.cola.backend.user.domain.User;
 import kr.or.cola.backend.auth.dto.SignUpRequestDto;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/kr/or/cola/backend/common/ResponseWithPagination.java
+++ b/src/main/java/kr/or/cola/backend/common/ResponseWithPagination.java
@@ -1,0 +1,13 @@
+package kr.or.cola.backend.common;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResponseWithPagination<T> {
+    private final Integer page;
+    private final Integer size;
+    private final List<T> data;
+}

--- a/src/main/java/kr/or/cola/backend/post/domain/PostRepository.java
+++ b/src/main/java/kr/or/cola/backend/post/domain/PostRepository.java
@@ -1,13 +1,10 @@
 package kr.or.cola.backend.post.domain;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p ORDER BY p.id DESC")
     List<Post> findAllDesc();
-
 }

--- a/src/main/java/kr/or/cola/backend/post/domain/PostRepository.java
+++ b/src/main/java/kr/or/cola/backend/post/domain/PostRepository.java
@@ -1,10 +1,13 @@
 package kr.or.cola.backend.post.domain;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p ORDER BY p.id DESC")
     List<Post> findAllDesc();
+
 }

--- a/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
+++ b/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
@@ -1,13 +1,17 @@
 package kr.or.cola.backend.post.presentation;
 
 
+import java.util.List;
+import kr.or.cola.backend.common.ResponseWithPagination;
 import kr.or.cola.backend.oauth.LoginUser;
 import kr.or.cola.backend.oauth.dto.SessionUser;
 import kr.or.cola.backend.post.presentation.dto.PostResponseDto;
 import kr.or.cola.backend.post.presentation.dto.PostCreateRequestDto;
 import kr.or.cola.backend.post.presentation.dto.PostUpdateRequestDto;
+import kr.or.cola.backend.post.presentation.dto.SimplePostResponseDto;
 import kr.or.cola.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/posts")
@@ -35,6 +40,20 @@ public class PostController {
     public ResponseEntity<Void> updatePost(@PathVariable Long postId, @RequestBody PostUpdateRequestDto requestDto) {
         postService.updatePost(postId, requestDto);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("")
+    public ResponseEntity<ResponseWithPagination<SimplePostResponseDto>> getPosts(
+        @RequestParam(value = "page", required = false) Integer page,
+        @RequestParam(value = "size", required = false) Integer size
+    ) {
+        page = page == null ? 0 : page;
+        size = size == null ? 12 : size;
+        PageRequest pageRequest = PageRequest.of(page, size);
+        List<SimplePostResponseDto> travels = postService.findAllPosts(pageRequest);
+        ResponseWithPagination<SimplePostResponseDto> paged =
+            new ResponseWithPagination<>(page, size, travels);
+        return ResponseEntity.ok(paged);
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
+++ b/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
@@ -13,6 +13,9 @@ import kr.or.cola.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,7 +46,8 @@ public class PostController {
     }
 
     @GetMapping("")
-    public ResponseEntity<Page<SimplePostResponseDto>> getPosts(final Pageable pageable) {
+    public ResponseEntity<Page<SimplePostResponseDto>> getPosts(
+        @PageableDefault(size = 12, sort = {"post_id"}, direction = Sort.Direction.DESC) Pageable pageable) {
         Page<SimplePostResponseDto> posts = postService.findAllPosts(pageable);
         return ResponseEntity.ok(posts);
     }

--- a/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
+++ b/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
@@ -11,7 +11,8 @@ import kr.or.cola.backend.post.presentation.dto.PostUpdateRequestDto;
 import kr.or.cola.backend.post.presentation.dto.SimplePostResponseDto;
 import kr.or.cola.backend.post.service.PostService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/posts")
@@ -43,17 +43,9 @@ public class PostController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ResponseWithPagination<SimplePostResponseDto>> getPosts(
-        @RequestParam(value = "page", required = false) Integer page,
-        @RequestParam(value = "size", required = false) Integer size
-    ) {
-        page = page == null ? 0 : page;
-        size = size == null ? 12 : size;
-        PageRequest pageRequest = PageRequest.of(page, size);
-        List<SimplePostResponseDto> travels = postService.findAllPosts(pageRequest);
-        ResponseWithPagination<SimplePostResponseDto> paged =
-            new ResponseWithPagination<>(page, size, travels);
-        return ResponseEntity.ok(paged);
+    public ResponseEntity<Page<SimplePostResponseDto>> getPosts(final Pageable pageable) {
+        Page<SimplePostResponseDto> posts = postService.findAllPosts(pageable);
+        return ResponseEntity.ok(posts);
     }
 
     @GetMapping("/{postId}")

--- a/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
+++ b/src/main/java/kr/or/cola/backend/post/presentation/PostController.java
@@ -47,7 +47,7 @@ public class PostController {
 
     @GetMapping("")
     public ResponseEntity<Page<SimplePostResponseDto>> getPosts(
-        @PageableDefault(size = 12, sort = {"post_id"}, direction = Sort.Direction.DESC) Pageable pageable) {
+        @PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<SimplePostResponseDto> posts = postService.findAllPosts(pageable);
         return ResponseEntity.ok(posts);
     }

--- a/src/main/java/kr/or/cola/backend/post/service/PostService.java
+++ b/src/main/java/kr/or/cola/backend/post/service/PostService.java
@@ -61,6 +61,7 @@ public class PostService {
             .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public Page<SimplePostResponseDto> findAllPosts(Pageable pageable) {
         return postRepository.findAll(pageable)
             .map(SimplePostResponseDto::new);

--- a/src/main/java/kr/or/cola/backend/post/service/PostService.java
+++ b/src/main/java/kr/or/cola/backend/post/service/PostService.java
@@ -13,9 +13,8 @@ import kr.or.cola.backend.user.domain.User;
 import kr.or.cola.backend.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
-import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties.Pageable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,10 +61,9 @@ public class PostService {
             .collect(Collectors.toList());
     }
 
-    public List<SimplePostResponseDto> findAllPosts(PageRequest pageRequest) {
-        return postRepository.findAll(pageRequest).stream()
-            .map(SimplePostResponseDto::new)
-            .collect(Collectors.toList());
+    public Page<SimplePostResponseDto> findAllPosts(Pageable pageable) {
+        return postRepository.findAll(pageable)
+            .map(SimplePostResponseDto::new);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/kr/or/cola/backend/post/service/PostService.java
+++ b/src/main/java/kr/or/cola/backend/post/service/PostService.java
@@ -13,6 +13,9 @@ import kr.or.cola.backend.user.domain.User;
 import kr.or.cola.backend.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties.Pageable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -55,6 +58,12 @@ public class PostService {
     @Transactional(readOnly = true)
     public List<SimplePostResponseDto> findAllDesc() {
         return postRepository.findAllDesc().stream()
+            .map(SimplePostResponseDto::new)
+            .collect(Collectors.toList());
+    }
+
+    public List<SimplePostResponseDto> findAllPosts(PageRequest pageRequest) {
+        return postRepository.findAll(pageRequest).stream()
             .map(SimplePostResponseDto::new)
             .collect(Collectors.toList());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,6 +33,8 @@ spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000
 spring.mail.properties.mail.smtp.writetimeout=5000
 
+spring.data.web.pageable.default-page-size=12
+
 # aws s3
 cloud.aws.credentials.accessKey=${S3_ACCESS_KEY:test}
 cloud.aws.credentials.secretKey=${S3_SECRET_KEY:test}

--- a/src/test/java/kr/or/cola/backend/post/presentation/PostControllerTest.java
+++ b/src/test/java/kr/or/cola/backend/post/presentation/PostControllerTest.java
@@ -1,0 +1,84 @@
+package kr.or.cola.backend.post.presentation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import kr.or.cola.backend.post.domain.Post;
+import kr.or.cola.backend.post.domain.PostRepository;
+import kr.or.cola.backend.post.service.PostService;
+import kr.or.cola.backend.user.domain.Role;
+import kr.or.cola.backend.user.domain.User;
+import kr.or.cola.backend.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.context.WebApplicationContext;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PostControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    public void setup(){
+        mvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+    }
+
+    @WithMockUser(roles = "USER")
+    @Test
+    void getPostsTest() throws Exception {
+        // given
+        int TOTAL_POST_COUNT = 20;
+        User user = userRepository.save(User.builder()
+            .role(Role.USER)
+            .email("test@test.com")
+            .build());
+        for(int i=0; i<TOTAL_POST_COUNT; i++) {
+            postRepository.save(Post.builder()
+                .user(user)
+                .title("title" + i)
+                .content("content" + i)
+                .build()
+            );
+        }
+        String url = "http://localhost:" + port + "/api/v1/posts";
+
+        // when
+        MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
+        info.add("size", "6");
+        info.add("page", "0");
+
+        mvc.perform(get(url)
+                .params(info))
+            .andExpect(status().isOk())
+            .andDo(print());
+    }
+}

--- a/src/test/java/kr/or/cola/backend/post/service/PostServiceTest.java
+++ b/src/test/java/kr/or/cola/backend/post/service/PostServiceTest.java
@@ -36,7 +36,7 @@ class PostServiceTest {
     private PostService postService;
 
     @Test
-    void findAllPosts() {
+    void findAllPostsTest() {
         // given
         int TOTAL_POST_COUNT = 20;
         int PAGE_SIZE = 6;

--- a/src/test/java/kr/or/cola/backend/post/service/PostServiceTest.java
+++ b/src/test/java/kr/or/cola/backend/post/service/PostServiceTest.java
@@ -1,0 +1,74 @@
+package kr.or.cola.backend.post.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Collectors;
+import kr.or.cola.backend.post.domain.Post;
+import kr.or.cola.backend.post.domain.PostRepository;
+import kr.or.cola.backend.post.presentation.dto.SimplePostResponseDto;
+import kr.or.cola.backend.user.UserService;
+import kr.or.cola.backend.user.domain.Role;
+import kr.or.cola.backend.user.domain.User;
+import kr.or.cola.backend.user.domain.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class PostServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PostService postService;
+
+    @Test
+    void findAllPosts() {
+        // given
+        int TOTAL_POST_COUNT = 20;
+        int PAGE_SIZE = 6;
+        User user = userRepository.save(User.builder()
+            .role(Role.USER)
+            .email("test@test.com")
+            .build());
+        for(int i=0; i<TOTAL_POST_COUNT; i++) {
+            postRepository.save(Post.builder()
+                .user(user)
+                .title("title" + i)
+                .content("content" + i)
+                .build()
+            );
+        }
+
+        // when
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+        Page<SimplePostResponseDto> result = postService.findAllPosts(pageable);
+
+        // then
+//        System.out.println("PAGE SIZE: " + result.getSize());
+//        System.out.println("TOTAL PAGE: " + result.getTotalPages());
+//        System.out.println("TOTAL COUNT: " + result.getTotalElements());
+//        System.out.println("NEXT: " + result.nextPageable());
+//        System.out.println("CONTENTS TITLE");
+//        System.out.println(result.getContent().stream()
+//            .map(SimplePostResponseDto::getPostId)
+//            .collect(Collectors.toList()));
+//        System.out.println(result);
+        assertThat(result.getTotalElements()).isEqualTo(TOTAL_POST_COUNT);
+        assertThat(result.getTotalPages()).isEqualTo(TOTAL_POST_COUNT / PAGE_SIZE + 1);
+        assertThat(result.getSize()).isEqualTo(PAGE_SIZE);
+    }
+}


### PR DESCRIPTION
### 🔨 작업 내용
- Posts pagination api 구현
### 📐 구현한 내용
- findAllPosts + pagination service/controller 구현
- `findAllPosts()` Service test 작성
- `getPosts()` Controller test 작성
  - **params**
    - page (default = 0)
    - size (default = 12)
    - sort (defualt = order by id desc)
  - **response**
    - `pageNumber`은 현재 페이지를 나타냅니다. **_<<<0부터 시작합니다.>>>_**
    - `first`, `last`를 통해 첫 번째와 마지막 페이지 여부 확인이 가능합니다.
    - `total pages`를 통해 결과가 총 몇 페이지인지 확인이 가능합니다.
    - `size`는 한 페이지에 표시할 elements 수를 나타냅니다. (defualt = 12)
    - `numberOfElements`는 현재 페이지의 elements 수를 나타냅니다.
### 🚧 논의 사항
- api 호출 시 size, sort는 따로 넣지 않아도 될 것으로 보입니다.
- **page의 시작 번호가 0**인 것에 주의하세요.
